### PR TITLE
Add tabbed workspace and enhance finance summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import ParticipantManager from './components/ParticipantManager';
 import ExpenseManager from './components/ExpenseManager';
 import IncomeManager from './components/IncomeManager';
@@ -5,6 +7,38 @@ import TransferManager from './components/TransferManager';
 import SummaryPanel from './components/SummaryPanel';
 
 const App = () => {
+  const managementSections = useMemo(
+    () => [
+      {
+        id: 'participants',
+        label: 'Participants',
+        description: 'Create your roster and personalise each member.',
+        component: <ParticipantManager />,
+      },
+      {
+        id: 'expenses',
+        label: 'Expenses',
+        description: 'Capture what everyone has paid so far.',
+        component: <ExpenseManager />,
+      },
+      {
+        id: 'income',
+        label: 'Income',
+        description: 'Log refunds or money flowing into the pot.',
+        component: <IncomeManager />,
+      },
+      {
+        id: 'transfers',
+        label: 'Transfers',
+        description: 'Track manual paybacks or adjustments.',
+        component: <TransferManager />,
+      },
+    ],
+    [],
+  );
+  const [activeSectionId, setActiveSectionId] = useState(managementSections[0].id);
+  const activeSection = managementSections.find((section) => section.id === activeSectionId);
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="absolute inset-x-0 top-0 -z-10 h-[420px] bg-gradient-to-b from-ocean-500/20 via-slate-900/40 to-slate-950 blur-3xl" />
@@ -23,10 +57,55 @@ const App = () => {
 
         <main className="mt-12 grid gap-8 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
           <div className="space-y-8">
-            <ParticipantManager />
-            <ExpenseManager />
-            <IncomeManager />
-            <TransferManager />
+            <div className="rounded-3xl border border-white/5 bg-slate-900/40 p-4 shadow-lg shadow-slate-950/40 sm:p-6">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Workspace</p>
+                    <h2 className="mt-1 text-lg font-semibold text-white sm:text-xl">Manage your shared wallet</h2>
+                  </div>
+                </div>
+                <div className="flex gap-2 overflow-x-auto rounded-2xl bg-slate-950/60 p-1 text-sm font-medium shadow-inner shadow-slate-950/60">
+                  {managementSections.map((section) => {
+                    const isActive = section.id === activeSectionId;
+                    return (
+                      <button
+                        key={section.id}
+                        type="button"
+                        onClick={() => setActiveSectionId(section.id)}
+                        className={`flex min-w-[140px] flex-1 items-center justify-center rounded-2xl px-4 py-2 transition ${
+                          isActive
+                            ? 'bg-gradient-to-r from-ocean-500 via-blossom-500 to-ocean-400 text-white shadow-lg shadow-ocean-900/30'
+                            : 'text-slate-300 hover:text-white'
+                        }`}
+                      >
+                        {section.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                {activeSection ? (
+                  <div className="rounded-3xl border border-white/5 bg-white/5 p-5">
+                    <p className="text-sm text-slate-300">{activeSection.description}</p>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            <div className="relative">
+              <AnimatePresence mode="wait">
+                {activeSection ? (
+                  <motion.div
+                    key={activeSection.id}
+                    initial={{ opacity: 0, translateY: 12 }}
+                    animate={{ opacity: 1, translateY: 0 }}
+                    exit={{ opacity: 0, translateY: -12 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    {activeSection.component}
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
           </div>
           <div className="space-y-8">
             <SummaryPanel />

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -17,6 +17,15 @@ const SummaryPanel = () => {
     [participants, expenses, incomes, transfers],
   );
 
+  const decoratedTransfers = useMemo(() => {
+    const participantLookup = new Map(participants.map((participant) => [participant.id, participant]));
+    return transfers.map((transfer) => ({
+      transfer,
+      from: participantLookup.get(transfer.fromId),
+      to: participantLookup.get(transfer.toId),
+    }));
+  }, [participants, transfers]);
+
   const handleExportPdf = async () => {
     if (!summaryRef.current) {
       return;
@@ -171,6 +180,49 @@ const SummaryPanel = () => {
           ) : (
             <motion.p layout className="text-sm text-slate-400">
               Balances are even. Great job team! 🎉
+            </motion.p>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+            Manual transfers
+          </h3>
+          {decoratedTransfers.length > 0 ? (
+            <div className="space-y-3">
+              {decoratedTransfers.map(({ transfer, from, to }) => (
+                <motion.div
+                  layout
+                  key={transfer.id}
+                  className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-slate-900/40 px-4 py-3 text-sm text-slate-100 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-lg">{from?.emoji ?? '💸'}</span>
+                    <div>
+                      <p className="font-semibold text-white">
+                        {from ? from.name : 'Someone'}
+                        <span className="mx-2 text-slate-400">→</span>
+                        {to ? to.name : 'Someone'}
+                      </p>
+                      {transfer.reason ? (
+                        <p className="text-xs uppercase tracking-wide text-slate-400">{transfer.reason}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-emerald-200">
+                      {formatCurrency(transfer.amount)}
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      {new Date(transfer.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          ) : (
+            <motion.p layout className="text-sm text-slate-400">
+              No manual transfers yet. Any paybacks you record will appear here.
             </motion.p>
           )}
         </div>

--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -69,6 +69,7 @@ const calculateIncomeEffects = (
     const entry = ledger.get(participant.id)!;
     const adjustment = remainder > 0 ? 1 : 0;
     entry.balance += baseShare + adjustment;
+    entry.received += baseShare + adjustment;
     if (remainder > 0) {
       remainder -= 1;
     }
@@ -76,7 +77,6 @@ const calculateIncomeEffects = (
   const receiverEntry = ledger.get(income.receiverId);
   if (receiverEntry) {
     receiverEntry.balance -= cents;
-    receiverEntry.received += cents;
   }
 };
 


### PR DESCRIPTION
## Summary
- add a tabbed workspace so the participant, expense, income, and transfer tools are easier to browse on every screen size
- correct the income breakdown so each participant’s credited share is reflected in the summary balances
- surface recorded manual transfers inside the breakdown to highlight who has already sent money and why

## Testing
- npm run build *(fails: missing local `vite/client` type definitions because packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da73707a8c83268c11aa90fef333f3